### PR TITLE
Expanded the documentation of the K-Search client

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -130,17 +130,7 @@ Contact the technical counterpart of the K-Link network you want to connect to o
 
 ## <a name = 'list-k-links'>Non exhaustive list of publicly available K-Link networks</a>
 
-K-Link Asia (Climate Change, Sustainable Land use and Biodiversity in Central Asia):
-  + Landing page: https://www.klink.asia
-  + Endpoint: https://public.klink.asia/kcore
-  + Registry: https://public.klink.asia/registry
-
-SLM TJ (Sustainable Land Management Network in Tajikistan): 
-  + Landing page: https://slmtj.net
-  + Endpoint: ADD HERE THE ENDPOINT
-  + Registry: ADD HERE THE URL OF THE REGISTRY
-
-*Complete this list if you know of any other publicly available K-Link network that you would like to see listed here*
+See https://k-link.technology/network.html to find the Registry pages and Endpoints of a list of publicly available K-Link networks
 
 ## Development
 

--- a/readme.md
+++ b/readme.md
@@ -53,13 +53,13 @@ and the **Javascript before the closing `</body>`** tag.
 <script type="text/javascript" src="https://releases.klink.asia/k-search-js/0/k-search.min.js"></script>
 ```
 
-To initialize the K-Search library you can follow: (1) a javascript approach or (2) a data attribute based approach.
+Before proceeding make sure you have the [token](#token) and the [K-Link endpoint url](#endpoint)
 
-?[Before proceed make sure you have the token and the K-Link endpoint url]
+To initialize the K-Search library you can follow: (1) a javascript approach or (2) a data attribute based approach.
 
 More integration examples can be found in the [`examples` folder](./examples).
 
-### via Javascript
+### (1) via Javascript
 
 If you want to initialize the library via javascript you can do that by using the `ksearch` global functions.
 
@@ -83,20 +83,20 @@ By default the library search for the first element that has the `data-ksearch` 
 - `token: String`: (required) The API token to obtain access to the Search
 - `selector: String`: (default `[data-ksearch]`) Where in the page I should put the K-Search.
    If more elements matches on the page only the first one will be used
-- `display: String`: (default `overlay`) The display style.
- - overlay the search box is visible and can expand on top of the other elements of the page when active
- - embed the search box and the results are visible in a page area and cannot hide other elements already in the page
+- `display: String`: (default `overlay`) The display style:
+  + `overlay` the search box is visible and can expand on top of the other elements of the page when active
+  + `embed` the search box and the results are visible in a page area and cannot hide other elements already in the page
 - `collapsed: Boolean`: (default `false`) If the search form should be collapsed to use less space on the page
 - `expandable: Boolean`: (default `true`) If the search input should become bigger when user interacts with it and the
    search results. If the `collapsed` option is set to true the `expandable` option will always be active.
 - `language: String`: (default `en`) The language for user interface localization. Currently supported only `en`
 
-### via data attributes
+### (2) via data attributes
 
 This is the fastest configuration method as its done entirely in html
 
 ```html
-<div class="k-search" data-ksearch-auto data-token="<API_KEY>" data-url="<URL_TO_KLINK>"></div>
+<div class="k-search" data-ksearch-auto data-token="<API_KEY>" data-url="<URL_TO_K-LINK>"></div>
 ```
 
 The following data attributes are supported:
@@ -105,13 +105,42 @@ The following data attributes are supported:
    the configuration values
 - `data-url`: (required) The K-Link compatible endpoint to use for searching
 - `data-token`: (required) The API token to obtain access to the Search
-- `data-display`: The display style.
- - overlay the search box is visible and can expand on top of the other elements of the page when active. The
+- `data-display`: The display style:
+  + `overlay` the search box is visible and can expand on top of the other elements of the page when active. The
    results are presented in a dialog below the search input field
- - embed the search box and the results are visible in a page area and cannot hide other elements already in the page
+  + `embed` the search box and the results are visible in a page area and cannot hide other elements already in the page
 - `data-collapsed`: If the search form should be collapsed to use less space on the page, for example if used in the header.
   This is a boolean attribute, so no explicit value is required.
 
+## <a name = 'token'>How to get a token</a>
+
+Go to the registry page of the K-Link network you want to connect to (typically https://public.your_k-link_network/registry) and create an account. If you don't know the address of the registry, contact the technical counterpart of the K-Link network you want to connect to or check if this K-Link network is referenced [below](#list-k-links).
+
+Go to Applications and click on `Add`
+
+Give a name to the application on which the K-Search client will run, enter the domain of the app ("mywebsite.com", "mycompany.de", etc.) and choose the permissions "data-search" and "data-view"
+
+Put the status on `enabled`
+
+Click on `Save`, your token has been generated
+
+## <a name = 'endpoint'>How to get the K-Link endpoint url</a>
+
+Contact the technical counterpart of the K-Link network you want to connect to or check if this K-Link network is referenced [below](#list-k-links).
+
+## <a name = 'list-k-links'>Non exhaustive list of publicly available K-Link networks</a>
+
+K-Link Asia (Climate Change, Sustainable Land use and Biodiversity in Central Asia):
+  + Landing page: https://www.klink.asia
+  + Endpoint: https://public.klink.asia/kcore
+  + Registry: https://public.klink.asia/registry
+
+SLM TJ (Sustainable Land Management Network in Tajikistan): 
+  + Landing page: https://slmtj.net
+  + Endpoint: ADD HERE THE ENDPOINT
+  + Registry: ADD HERE THE URL OF THE REGISTRY
+
+*Complete this list if you know of any other publicly available K-Link network that you would like to see listed here*
 
 ## Development
 


### PR DESCRIPTION
- Corrected typos and layout
- Added explicit information on how to get tokens and endpoints
- Started a list of registry and endpoint URLs for freely available K-Link networks (IF YOU ACCEPT THIS CHANGE, PLEASE ADD URLS FOR SLMTJ)

Note: could the examples here https://github.com/shenriod/k-search-client-js/blob/documentation-k-search-client-js/examples be permanently hosted somewhere? So that the users / devs can directly see what each example looks like? Like is done for OpenLayers: http://openlayers.org/en/latest/examples/ e.g.